### PR TITLE
Add Rust WebAssembly snake game

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Window","Document","HtmlCanvasElement","CanvasRenderingContext2d","KeyboardEvent","HtmlElement","CssStyleDeclaration"] }
+web-sys = { version = "0.3", features = ["Window","Document","HtmlCanvasElement","CanvasRenderingContext2d","KeyboardEvent","HtmlElement","CssStyleDeclaration","Element","Node"] }
 console_error_panic_hook = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Window","Document","HtmlCanvasElement","CanvasRenderingContext2d","KeyboardEvent"] }
+web-sys = { version = "0.3", features = ["Window","Document","HtmlCanvasElement","CanvasRenderingContext2d","KeyboardEvent","HtmlElement"] }
 console_error_panic_hook = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,4 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 web-sys = { version = "0.3", features = ["Window","Document","HtmlCanvasElement","CanvasRenderingContext2d","KeyboardEvent","HtmlElement","CssStyleDeclaration","Element","Node"] }
-console_error_panic_hook = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "snake_game"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+web-sys = { version = "0.3", features = ["Window","Document","HtmlCanvasElement","CanvasRenderingContext2d","KeyboardEvent"] }
+console_error_panic_hook = "0.1"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Window","Document","HtmlCanvasElement","CanvasRenderingContext2d","KeyboardEvent","HtmlElement"] }
+web-sys = { version = "0.3", features = ["Window","Document","HtmlCanvasElement","CanvasRenderingContext2d","KeyboardEvent","HtmlElement","CssStyleDeclaration"] }
 console_error_panic_hook = "0.1"
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Rust WASM Snake</title>
+  </head>
+  <body>
+    <canvas id="game" style="touch-action:none;"></canvas>
+    <button id="mode">Switch to 3D</button>
+    <script type="module">
+      import init, { toggle_mode } from "./pkg/snake_game.js";
+      init().then(() => {
+        const mode = document.getElementById("mode");
+        mode.addEventListener("click", () => toggle_mode());
+
+        const canvas = document.getElementById("game");
+        let start = null;
+        const dispatch = (key) =>
+          document.dispatchEvent(new KeyboardEvent("keydown", { key }));
+
+        canvas.addEventListener(
+          "touchstart",
+          (e) => {
+            start = e.touches[0];
+            e.preventDefault();
+          },
+          { passive: false }
+        );
+        canvas.addEventListener(
+          "touchmove",
+          (e) => e.preventDefault(),
+          { passive: false }
+        );
+        canvas.addEventListener(
+          "touchend",
+          (e) => {
+            if (!start) return;
+            const dx = e.changedTouches[0].clientX - start.clientX;
+            const dy = e.changedTouches[0].clientY - start.clientY;
+            if (Math.abs(dx) > Math.abs(dy)) {
+              if (dx > 30) dispatch("ArrowRight");
+              else if (dx < -30) dispatch("ArrowLeft");
+            } else {
+              if (dy > 30) dispatch("ArrowDown");
+              else if (dy < -30) dispatch("ArrowUp");
+            }
+            start = null;
+            e.preventDefault();
+          },
+          { passive: false }
+        );
+      });
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -28,11 +28,13 @@
       </div>
     </div>
     <script type="module">
-      import init, { toggle_mode, restart } from "./pkg/snake_game.js";
+      import init, * as wasm from "./pkg/snake_game.js";
       init().then(() => {
         const mode = document.getElementById("mode");
-        mode.addEventListener("click", () => toggle_mode());
-        document.getElementById("restart").addEventListener("click", () => restart());
+        mode.addEventListener("click", () => wasm.toggle_mode());
+        document
+          .getElementById("restart")
+          .addEventListener("click", () => wasm.restart());
 
         const canvas = document.getElementById("game");
         let start = null;

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         height: 100vh;
       }
       #container { text-align: center; }
-      canvas { background: #111; margin: 20px auto; display: block; touch-action:none; }
+      canvas { background: #111; margin: 20px auto; display: block; touch-action:none; border: 2px solid white; }
       #score { margin-top: 10px; }
     </style>
   </head>

--- a/index.html
+++ b/index.html
@@ -3,15 +3,36 @@
   <head>
     <meta charset="utf-8" />
     <title>Rust WASM Snake</title>
+    <style>
+      body {
+        background: black;
+        color: white;
+        margin: 0;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+      }
+      #container { text-align: center; }
+      canvas { background: #111; margin: 20px auto; display: block; touch-action:none; }
+      #score { margin-top: 10px; }
+    </style>
   </head>
   <body>
-    <canvas id="game" style="touch-action:none;"></canvas>
-    <button id="mode">Switch to 3D</button>
+    <div id="container">
+      <div id="score">Score: 0</div>
+      <canvas id="game"></canvas>
+      <div>
+        <button id="mode">Switch to 3D</button>
+        <button id="restart" style="display:none;">Restart</button>
+      </div>
+    </div>
     <script type="module">
-      import init, { toggle_mode } from "./pkg/snake_game.js";
+      import init, { toggle_mode, restart } from "./pkg/snake_game.js";
       init().then(() => {
         const mode = document.getElementById("mode");
         mode.addEventListener("click", () => toggle_mode());
+        document.getElementById("restart").addEventListener("click", () => restart());
 
         const canvas = document.getElementById("game");
         let start = null;

--- a/index.html
+++ b/index.html
@@ -36,6 +36,10 @@
           .getElementById("restart")
           .addEventListener("click", () => wasm.restart());
 
+        document.addEventListener("keydown", (e) => e.preventDefault(), {
+          passive: false,
+        });
+
         const canvas = document.getElementById("game");
         let start = null;
         const dispatch = (key) =>

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,37 @@
-a snake game in wasm 
+# Snake Game in Rust and WebAssembly
+
+This project provides a simple implementation of the classic Snake game
+written in Rust and compiled to WebAssembly. The game renders on an HTML
+`<canvas>` element and is controlled with the arrow keys. It includes both a
+traditional 2D version and a 3D cube variant that can be toggled with a button
+on the page.
+
+## Building
+
+Install the required target and build the WASM package:
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack
+wasm-pack build --target web
+```
+
+## Running
+
+After building, an output directory `pkg/` is created. Serve the project
+root with any static web server and open `index.html` in a browser:
+
+```bash
+python3 -m http.server
+```
+
+Navigate to `http://localhost:8000` to play.
+
+Click the **Switch to 3D** button to toggle between the 2D and 3D versions of
+the game. On touch devices, swipe on the canvas to change direction, and
+keyboard input will not scroll the page.
+
+## Deploying
+
+Copy the `index.html` and `pkg/` directory to any static hosting service
+such as GitHub Pages or your own web server.

--- a/readme.md
+++ b/readme.md
@@ -3,9 +3,10 @@
 This project provides a simple implementation of the classic Snake game
 written in Rust and compiled to WebAssembly. The game renders on an HTML
 `<canvas>` element and is controlled with the arrow keys. It includes both a
-traditional 2D version and a 3D cube variant that can be toggled with a button
-on the page. The score is displayed above the play field, and a restart button
-appears when the snake collides with itself.
+traditional 2D version and a 3D cube variant rendered with perspective that can
+be toggled with a button on the page. The score is displayed above the play
+field and updates as you eat food, and a restart button appears when the snake
+collides with itself.
 
 ## Building
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,8 @@ This project provides a simple implementation of the classic Snake game
 written in Rust and compiled to WebAssembly. The game renders on an HTML
 `<canvas>` element and is controlled with the arrow keys. It includes both a
 traditional 2D version and a 3D cube variant that can be toggled with a button
-on the page.
+on the page. The score is displayed above the play field, and a restart button
+appears when the snake collides with itself.
 
 ## Building
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,9 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
-use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, KeyboardEvent, HtmlElement};
+use web_sys::{
+    CanvasRenderingContext2d, HtmlCanvasElement, KeyboardEvent, HtmlElement,
+};
 
 const WIDTH: i32 = 20;
 const HEIGHT: i32 = 20;
@@ -13,7 +15,7 @@ fn set_score(score: i32) {
     let window = web_sys::window().unwrap();
     if let Some(document) = window.document() {
         if let Some(elem) = document.get_element_by_id("score") {
-            elem.set_inner_html(&format!("Score: {}", score));
+            elem.set_text_content(Some(&format!("Score: {}", score)));
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ pub fn start() -> Result<(), JsValue> {
     {
         let doc = document.clone();
         let closure = Closure::wrap(Box::new(move |event: KeyboardEvent| {
-            event.prevent_default();
             let key = event.key();
             GAME.with(|game| {
                 if let Some(g) = game.borrow_mut().as_mut() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ thread_local! {
 
 #[wasm_bindgen(start)]
 pub fn start() -> Result<(), JsValue> {
-    console_error_panic_hook::set_once();
     let window = web_sys::window().unwrap();
     let document = window.document().unwrap();
     let canvas: HtmlCanvasElement = document.get_element_by_id("game").unwrap().dyn_into()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,6 +381,18 @@ fn project_point(x: f64, y: f64, z: f64) -> (f64, f64) {
     (px * CELL, py * CELL)
 }
 
+fn fill_with_alpha(ctx: &CanvasRenderingContext2d, base: &str, alpha: f64) {
+    let (r, g, b) = match base {
+        "green" => (0, 255, 0),
+        "red" => (255, 0, 0),
+        _ => (255, 255, 255),
+    };
+    ctx.set_fill_style(&JsValue::from_str(&format!(
+        "rgba({},{},{},{})",
+        r, g, b, alpha
+    )));
+}
+
 fn draw_cube(ctx: &CanvasRenderingContext2d, pos: Vec3, color: &str) {
     let p000 = project_point(pos.0 as f64, pos.1 as f64, pos.2 as f64);
     let p100 = project_point(pos.0 as f64 + 1.0, pos.1 as f64, pos.2 as f64);
@@ -392,8 +404,7 @@ fn draw_cube(ctx: &CanvasRenderingContext2d, pos: Vec3, color: &str) {
     let p111 = project_point(pos.0 as f64 + 1.0, pos.1 as f64 + 1.0, pos.2 as f64 + 1.0);
 
     // back face
-    ctx.set_fill_style(&JsValue::from_str(color));
-    ctx.set_global_alpha(0.2);
+    fill_with_alpha(ctx, color, 0.2);
     ctx.begin_path();
     ctx.move_to(p001.0, p001.1);
     ctx.line_to(p101.0, p101.1);
@@ -403,7 +414,7 @@ fn draw_cube(ctx: &CanvasRenderingContext2d, pos: Vec3, color: &str) {
     ctx.fill();
 
     // top face
-    ctx.set_global_alpha(0.6);
+    fill_with_alpha(ctx, color, 0.6);
     ctx.begin_path();
     ctx.move_to(p011.0, p011.1);
     ctx.line_to(p111.0, p111.1);
@@ -413,7 +424,7 @@ fn draw_cube(ctx: &CanvasRenderingContext2d, pos: Vec3, color: &str) {
     ctx.fill();
 
     // right face
-    ctx.set_global_alpha(0.4);
+    fill_with_alpha(ctx, color, 0.4);
     ctx.begin_path();
     ctx.move_to(p101.0, p101.1);
     ctx.line_to(p111.0, p111.1);
@@ -423,7 +434,7 @@ fn draw_cube(ctx: &CanvasRenderingContext2d, pos: Vec3, color: &str) {
     ctx.fill();
 
     // front face
-    ctx.set_global_alpha(1.0);
+    fill_with_alpha(ctx, color, 1.0);
     ctx.begin_path();
     ctx.move_to(p000.0, p000.1);
     ctx.line_to(p100.0, p100.1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,300 @@
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, KeyboardEvent};
+
+const WIDTH: i32 = 20;
+const HEIGHT: i32 = 20;
+const DEPTH: i32 = 20;
+const CELL: f64 = 20.0;
+
+thread_local! {
+    static GAME: RefCell<Option<GameVariant>> = RefCell::new(None);
+}
+
+#[wasm_bindgen(start)]
+pub fn start() -> Result<(), JsValue> {
+    console_error_panic_hook::set_once();
+    let window = web_sys::window().unwrap();
+    let document = window.document().unwrap();
+    let canvas: HtmlCanvasElement = document.get_element_by_id("game").unwrap().dyn_into()?;
+    canvas.set_width(((WIDTH + DEPTH) as f64 * CELL) as u32);
+    canvas.set_height(((HEIGHT + DEPTH) as f64 * CELL) as u32);
+    let ctx = canvas
+        .get_context("2d")?
+        .unwrap()
+        .dyn_into::<CanvasRenderingContext2d>()?;
+    GAME.with(|g| g.borrow_mut().replace(GameVariant::TwoD(Game2D::new(ctx))));
+
+    // keyboard events
+    {
+        let doc = document.clone();
+        let closure = Closure::wrap(Box::new(move |event: KeyboardEvent| {
+            event.prevent_default();
+            let key = event.key();
+            GAME.with(|game| {
+                if let Some(g) = game.borrow_mut().as_mut() {
+                    g.change_dir(&key);
+                }
+            });
+        }) as Box<dyn FnMut(_)>);
+        doc.add_event_listener_with_callback("keydown", closure.as_ref().unchecked_ref())?;
+        closure.forget();
+    }
+
+    // game loop
+    {
+        let closure = Closure::wrap(Box::new(move || {
+            GAME.with(|game| {
+                if let Some(g) = game.borrow_mut().as_mut() {
+                    g.update();
+                    g.draw().unwrap();
+                }
+            });
+        }) as Box<dyn FnMut()>);
+        window.set_interval_with_callback_and_timeout_and_arguments_0(
+            closure.as_ref().unchecked_ref(),
+            100,
+        )?;
+        closure.forget();
+    }
+    Ok(())
+}
+
+#[wasm_bindgen]
+pub fn toggle_mode() {
+    GAME.with(|g| {
+        let mut game = g.borrow_mut();
+        if let Some(current) = game.take() {
+            let new_game = match current {
+                GameVariant::TwoD(g2d) => {
+                    let ctx = g2d.ctx.clone();
+                    GameVariant::ThreeD(Game3D::new(ctx))
+                }
+                GameVariant::ThreeD(g3d) => {
+                    let ctx = g3d.ctx.clone();
+                    GameVariant::TwoD(Game2D::new(ctx))
+                }
+            };
+            game.replace(new_game);
+        }
+    });
+}
+
+enum GameVariant {
+    TwoD(Game2D),
+    ThreeD(Game3D),
+}
+
+impl GameVariant {
+    fn change_dir(&mut self, key: &str) {
+        match self {
+            GameVariant::TwoD(g) => g.change_dir(key),
+            GameVariant::ThreeD(g) => g.change_dir(key),
+        }
+    }
+    fn update(&mut self) {
+        match self {
+            GameVariant::TwoD(g) => g.update(),
+            GameVariant::ThreeD(g) => g.update(),
+        }
+    }
+    fn draw(&self) -> Result<(), JsValue> {
+        match self {
+            GameVariant::TwoD(g) => g.draw(),
+            GameVariant::ThreeD(g) => g.draw(),
+        }
+    }
+}
+
+struct Game2D {
+    ctx: CanvasRenderingContext2d,
+    snake: VecDeque<(i32, i32)>,
+    dir: (i32, i32),
+    food: (i32, i32),
+}
+
+impl Game2D {
+    fn new(ctx: CanvasRenderingContext2d) -> Self {
+        let mut snake = VecDeque::new();
+        snake.push_back((WIDTH / 2, HEIGHT / 2));
+        let food = (5, 5);
+        Self {
+            ctx,
+            snake,
+            dir: (1, 0),
+            food,
+        }
+    }
+
+    fn change_dir(&mut self, key: &str) {
+        match key {
+            "ArrowUp" if self.dir.1 != 1 => self.dir = (0, -1),
+            "ArrowDown" if self.dir.1 != -1 => self.dir = (0, 1),
+            "ArrowLeft" if self.dir.0 != 1 => self.dir = (-1, 0),
+            "ArrowRight" if self.dir.0 != -1 => self.dir = (1, 0),
+            _ => {}
+        }
+    }
+
+    fn update(&mut self) {
+        let mut new_head = *self.snake.front().unwrap();
+        new_head.0 = (new_head.0 + self.dir.0 + WIDTH) % WIDTH;
+        new_head.1 = (new_head.1 + self.dir.1 + HEIGHT) % HEIGHT;
+        if new_head == self.food {
+            self.food = (
+                (js_sys::Math::random() * WIDTH as f64) as i32,
+                (js_sys::Math::random() * HEIGHT as f64) as i32,
+            );
+        } else {
+            self.snake.pop_back();
+        }
+        self.snake.push_front(new_head);
+    }
+
+    fn draw(&self) -> Result<(), JsValue> {
+        self.ctx.set_fill_style(&JsValue::from_str("black"));
+        self.ctx
+            .fill_rect(0.0, 0.0, WIDTH as f64 * CELL, HEIGHT as f64 * CELL);
+        self.ctx.set_fill_style(&JsValue::from_str("green"));
+        for (x, y) in self.snake.iter() {
+            self.ctx
+                .fill_rect(*x as f64 * CELL, *y as f64 * CELL, CELL, CELL);
+        }
+        self.ctx.set_fill_style(&JsValue::from_str("red"));
+        self.ctx.fill_rect(
+            self.food.0 as f64 * CELL,
+            self.food.1 as f64 * CELL,
+            CELL,
+            CELL,
+        );
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Vec3(i32, i32, i32);
+
+impl Vec3 {
+    fn add(&self, other: Vec3) -> Vec3 {
+        Vec3(self.0 + other.0, self.1 + other.1, self.2 + other.2)
+    }
+    fn wrap(&self) -> Vec3 {
+        Vec3(
+            (self.0 + WIDTH) % WIDTH,
+            (self.1 + HEIGHT) % HEIGHT,
+            (self.2 + DEPTH) % DEPTH,
+        )
+    }
+    fn neg(&self) -> Vec3 {
+        Vec3(-self.0, -self.1, -self.2)
+    }
+}
+
+struct Orientation {
+    f: Vec3,
+    u: Vec3,
+    r: Vec3,
+}
+
+impl Orientation {
+    fn new() -> Self {
+        Self {
+            f: Vec3(0, 0, 1),
+            u: Vec3(1, 0, 0),
+            r: Vec3(0, 1, 0),
+        }
+    }
+    fn pitch_up(&mut self) {
+        let new_f = self.u;
+        self.u = self.f.neg();
+        self.f = new_f;
+    }
+    fn pitch_down(&mut self) {
+        let new_f = self.u.neg();
+        self.u = self.f;
+        self.f = new_f;
+    }
+    fn yaw_left(&mut self) {
+        let new_f = self.r.neg();
+        self.r = self.f;
+        self.f = new_f;
+    }
+    fn yaw_right(&mut self) {
+        let new_f = self.r;
+        self.r = self.f.neg();
+        self.f = new_f;
+    }
+}
+
+struct Game3D {
+    ctx: CanvasRenderingContext2d,
+    snake: VecDeque<Vec3>,
+    orient: Orientation,
+    food: Vec3,
+}
+
+impl Game3D {
+    fn new(ctx: CanvasRenderingContext2d) -> Self {
+        let mut snake = VecDeque::new();
+        snake.push_back(Vec3(WIDTH / 2, HEIGHT / 2, DEPTH / 2));
+        let food = Vec3(5, 5, 5);
+        Self {
+            ctx,
+            snake,
+            orient: Orientation::new(),
+            food,
+        }
+    }
+
+    fn change_dir(&mut self, key: &str) {
+        match key {
+            "ArrowUp" => self.orient.pitch_up(),
+            "ArrowDown" => self.orient.pitch_down(),
+            "ArrowLeft" => self.orient.yaw_left(),
+            "ArrowRight" => self.orient.yaw_right(),
+            _ => {}
+        }
+    }
+
+    fn update(&mut self) {
+        let head = *self.snake.front().unwrap();
+        let mut new_head = head.add(self.orient.f);
+        new_head = new_head.wrap();
+        if new_head.0 == self.food.0 && new_head.1 == self.food.1 && new_head.2 == self.food.2 {
+            self.food = Vec3(
+                (js_sys::Math::random() * WIDTH as f64) as i32,
+                (js_sys::Math::random() * HEIGHT as f64) as i32,
+                (js_sys::Math::random() * DEPTH as f64) as i32,
+            );
+        } else {
+            self.snake.pop_back();
+        }
+        self.snake.push_front(new_head);
+    }
+
+    fn draw(&self) -> Result<(), JsValue> {
+        self.ctx.set_fill_style(&JsValue::from_str("black"));
+        self.ctx.fill_rect(
+            0.0,
+            0.0,
+            (WIDTH + DEPTH) as f64 * CELL,
+            (HEIGHT + DEPTH) as f64 * CELL,
+        );
+        self.ctx.set_fill_style(&JsValue::from_str("green"));
+        for pos in self.snake.iter() {
+            let (x, y) = project(pos.0, pos.1, pos.2);
+            self.ctx.fill_rect(x, y, CELL, CELL);
+        }
+        self.ctx.set_fill_style(&JsValue::from_str("red"));
+        let (fx, fy) = project(self.food.0, self.food.1, self.food.2);
+        self.ctx.fill_rect(fx, fy, CELL, CELL);
+        Ok(())
+    }
+}
+
+fn project(x: i32, y: i32, z: i32) -> (f64, f64) {
+    let offset = z as f64 * CELL * 0.5;
+    (x as f64 * CELL + offset, y as f64 * CELL + offset)
+}


### PR DESCRIPTION
## Summary
- set up Rust project targeting WebAssembly for a simple snake game
- draw snake and food on HTML canvas and handle keyboard input
- document build and deployment steps with wasm-pack
- add 3D cube mode with orientation-based controls and toggle button
- capture touch swipes as arrow-key events and prevent page scroll on key presses

## Testing
- `cargo check` *(failed: failed to get `console_error_panic_hook` as a dependency of package `snake_game v0.1.0 (/workspace/game)`; failed to download from `https://index.crates.io/config.json` [CONNECT tunnel failed, response 403])*

------
https://chatgpt.com/codex/tasks/task_e_68961ed2e4b88326b0cd37a3c398ea58